### PR TITLE
Added Jira URL and user

### DIFF
--- a/cmd/project/settings.go
+++ b/cmd/project/settings.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/mvannes/golab/gitlab"
@@ -53,7 +54,9 @@ var settingsForNamespaceCmd = &cobra.Command{
 	},
 }
 var flagCommitEventsWillUpdateJira bool
+var flagJiraUserName string
 var flagJiraUserPassword string
+var flagJiraUrl string
 
 var jiraSettingsCmd = &cobra.Command{
 	Use:   "jira-settings",
@@ -67,8 +70,11 @@ var jiraSettingsCmd = &cobra.Command{
 		}
 
 		settings := gitlab.ProjectJiraSettings{
+			URL:      flagJiraUrl,
+			Username: flagJiraUserName,
 			Password: flagJiraUserPassword,
 		}
+
 		if cmd.Flag("commits-update-jira").Changed {
 			settings.CommitEventsUpdateJira = &flagCommitEventsWillUpdateJira
 		}
@@ -92,6 +98,8 @@ var jiraSettingsForNamespaceCmd = &cobra.Command{
 		}
 
 		settings := gitlab.ProjectJiraSettings{
+			URL:      flagJiraUrl,
+			Username: flagJiraUserName,
 			Password: flagJiraUserPassword,
 		}
 		if cmd.Flag("commits-update-jira").Changed {
@@ -102,6 +110,8 @@ var jiraSettingsForNamespaceCmd = &cobra.Command{
 			if p.Archived {
 				continue
 			}
+
+			fmt.Println(p.Name)
 
 			err = c.UpdateJiraIntegration(p, settings)
 			if err != nil {
@@ -117,11 +127,19 @@ func init() {
 	settingsForNamespaceCmd.Flags().BoolVarP(&flagRemoveSourceBranch, "remove-source-branch", "r", false, "update remove source branch value")
 
 	jiraSettingsCmd.Flags().BoolVarP(&flagCommitEventsWillUpdateJira, "commits-update-jira", "c", false, "update commit events update jira value")
+	jiraSettingsCmd.Flags().StringVarP(&flagJiraUrl, "jira-url", "x", "", "MUST PROVIDE, the jira URL to update to.")
+	jiraSettingsCmd.Flags().StringVarP(&flagJiraUserName, "jira-user", "u", "", "MUST PROVIDE, the jira user name to update to.")
 	jiraSettingsCmd.Flags().StringVarP(&flagJiraUserPassword, "jira-password", "p", "", "MUST PROVIDE, the jira user password to update to.")
+	jiraSettingsCmd.MarkFlagRequired("jira-url")
+	jiraSettingsCmd.MarkFlagRequired("jira-user")
 	jiraSettingsCmd.MarkFlagRequired("jira-password")
 
 	jiraSettingsForNamespaceCmd.Flags().BoolVarP(&flagCommitEventsWillUpdateJira, "commits-update-jira", "c", false, "update commit events update jira value")
+	jiraSettingsForNamespaceCmd.Flags().StringVarP(&flagJiraUrl, "jira-url", "x", "", "MUST PROVIDE, the jira URL to update to.")
+	jiraSettingsForNamespaceCmd.Flags().StringVarP(&flagJiraUserName, "jira-user", "u", "", "MUST PROVIDE, the jira user name to update to.")
 	jiraSettingsForNamespaceCmd.Flags().StringVarP(&flagJiraUserPassword, "jira-password", "p", "", "MUST PROVIDE, the jira user password to update to.")
+	jiraSettingsForNamespaceCmd.MarkFlagRequired("jira-url")
+	jiraSettingsForNamespaceCmd.MarkFlagRequired("jira-user")
 	jiraSettingsForNamespaceCmd.MarkFlagRequired("jira-password")
 
 	projectCmd.AddCommand(settingsCmd)

--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -239,6 +239,8 @@ func (g *GitlabClient) SetOptions(p gitlab.Project, settings ProjectSettings) er
 }
 
 type ProjectJiraSettings struct {
+	URL                    string
+	Username               string
 	Password               string
 	CommitEventsUpdateJira *bool
 }
@@ -258,29 +260,22 @@ func (g *GitlabClient) UpdateJiraIntegration(p gitlab.Project, s ProjectJiraSett
 		return nil
 	}
 
-	j, err := g.GetJiraIntegration(p)
-	if nil != err {
-		return err
-	}
+	active := true
+	CommentOnEventEnabled := false
 
 	opts := &gitlab.SetJiraServiceOptions{
-		URL:                   &j.Properties.URL,
-		APIURL:                &j.Properties.APIURL,
-		ProjectKey:            &j.Properties.ProjectKey,
-		Username:              &j.Properties.Username,
+		URL:                   &s.URL,
+		Username:              &s.Username,
 		Password:              &s.Password,
-		Active:                &j.Active,
-		JiraIssueTransitionID: &j.Properties.JiraIssueTransitionID,
-		CommitEvents:          &j.CommitEvents,
-		MergeRequestsEvents:   &j.MergeRequestsEvents,
-		CommentOnEventEnabled: &j.CommentOnEventEnabled,
+		Active:                &active,
+		CommentOnEventEnabled: &CommentOnEventEnabled,
 	}
 
 	if s.HasChanges() {
 		opts.CommitEvents = s.CommitEventsUpdateJira
 	}
 
-	_, err = g.gitlab.Services.SetJiraService(p.ID, opts)
+	_, err := g.gitlab.Services.SetJiraService(p.ID, opts)
 
 	return err
 }


### PR DESCRIPTION
Some small changes:
 - 404's on the gitlab integration call no longer result in an error, but give a `nil` result. This is needed because if you have not configured the integration, you want to distinguish this case from an actual api error.
 - Added the JIRA url and username. 
 - Removed all the other stuff, if not passed it will leave it at whatever it is already set. Do it is the same behavior but now also falls back to default values for projects which did not have it configured.